### PR TITLE
Shift and widen message timestamp

### DIFF
--- a/Zulip/MessageCellView.xib
+++ b/Zulip/MessageCellView.xib
@@ -42,7 +42,7 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             </view>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="ts" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="102">
-                                <rect key="frame" x="282" y="0.0" width="33" height="21"/>
+                                <rect key="frame" x="273" y="0.0" width="42" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>


### PR DESCRIPTION
As per #3, the timestamps on messages are being truncated with an ellipsis. This widens and shifts over the timestamp rectangle show "12:24" instead of "12:…". (9 pixels should probably do the trick.)
