### PR TITLE
Proper showing of LoginController

### DIFF
--- a/Zulip/Controllers/ViewControllers/LeftSidebarViewController.m
+++ b/Zulip/Controllers/ViewControllers/LeftSidebarViewController.m
@@ -356,12 +356,8 @@
         // Logout
         [[ZulipAPIController sharedInstance] logout];
 
-        LoginViewController *loginView = [[LoginViewController alloc] initWithNibName:@"LoginViewController"
-                                                                               bundle:nil];
-        [self.findSidePanelController toggleLeftPanel:self];
-
         ZulipAppDelegate *delegate = (ZulipAppDelegate *)[[UIApplication sharedApplication] delegate];
-        [[delegate navController] pushViewController:loginView animated:YES];
+        [delegate showLoginScreen];
     }
 
     // Update selected state of all rows

--- a/Zulip/LoginViewController.m
+++ b/Zulip/LoginViewController.m
@@ -3,6 +3,7 @@
 #import "ZulipAPIController.h"
 #import "ZulipAPIClient.h"
 #import "GoogleOAuthManager.h"
+#import "AboutViewController.h"
 
 #import "BrowserViewController.h"
 #import "UIView+Layout.h"
@@ -28,7 +29,6 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [self.navigationController setNavigationBarHidden:YES animated:YES];
 
     self.password.secureTextEntry = YES;
     self.appDelegate = (ZulipAppDelegate *)[[UIApplication sharedApplication] delegate];
@@ -45,6 +45,11 @@
 
     // Focus on email field.
     [self.email becomeFirstResponder];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.navigationController setNavigationBarHidden:YES animated:YES];
 }
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
@@ -99,7 +104,8 @@
 
 - (IBAction) about:(id)sender
 {
-    [self.appDelegate showAboutScreen];
+    AboutViewController *about = [[AboutViewController alloc] initWithNibName:@"AboutView" bundle:nil];
+    [self.navigationController pushViewController:about animated:YES];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {

--- a/Zulip/ZulipAppDelegate.h
+++ b/Zulip/ZulipAppDelegate.h
@@ -11,6 +11,7 @@
 @property (nonatomic, retain) UIWindow *window;
 @property (nonatomic, retain) UITabBarController *tabBarController;
 @property (nonatomic, retain) UINavigationController *navController;
+@property (nonatomic, retain) UINavigationController *loginNavController;
 @property (nonatomic, retain) JASidePanelController *sidePanelController;
 @property (nonatomic, retain) LoginViewController *loginViewController;
 @property (nonatomic, retain) HomeViewController *homeViewController;
@@ -28,8 +29,8 @@
 
 - (void) showErrorScreen:(NSString *)errorMessage;
 - (void) dismissErrorScreen;
+- (void) showLoginScreen;
 - (void) dismissLoginScreen;
-- (void) showAboutScreen;
 
 // Narrowing
 - (void) narrowWithOperators:(NarrowOperators *)narrow;

--- a/Zulip/ZulipAppDelegate.m
+++ b/Zulip/ZulipAppDelegate.m
@@ -6,7 +6,6 @@
 #import "LeftSidebarViewController.h"
 #import "RightSidebarViewController.h"
 #import "NarrowViewController.h"
-#import "AboutViewController.h"
 #import "PresenceManager.h"
 #import "NSArray+Blocks.h"
 
@@ -80,14 +79,12 @@
     // Connect the API controller to the home view, and connect to the Zulip API
     [[ZulipAPIController sharedInstance] setHomeViewController:self.homeViewController];
 
+    [[self window] setRootViewController:self.sidePanelController];
+
     if (![[ZulipAPIController sharedInstance] loggedIn]) {
         // No credentials stored; we need to log in.
-        self.loginViewController = [[LoginViewController alloc] init];
-        self.sidePanelController.recognizesPanGesture = NO;
-        [self.navController pushViewController:self.loginViewController animated:YES];
+        [self showLoginScreen];
     }
-
-    [[self window] setRootViewController:self.sidePanelController];
 
     // Set out NSURLCache settings
     NSURLCache *URLCache = [[NSURLCache alloc] initWithMemoryCapacity:4 * 1024 * 1024 diskCapacity:20 * 1024 * 1024 diskPath:nil];
@@ -131,10 +128,18 @@
     return YES;
 }
 
+- (void)showLoginScreen
+{
+    self.loginViewController = [[LoginViewController alloc] init];
+    self.loginNavController = [[UINavigationController alloc] initWithRootViewController:self.loginViewController];
+    [self.sidePanelController presentViewController:self.loginNavController animated:YES completion:nil];
+    self.sidePanelController.recognizesPanGesture = NO;
+}
+
 - (void)dismissLoginScreen
 {
     self.sidePanelController.recognizesPanGesture = YES;
-    [self.navController popViewControllerAnimated:YES];
+    [self.sidePanelController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)showErrorScreen:(NSString *)errorMessage
@@ -142,7 +147,6 @@
     if ([self.window.subviews containsObject:self.errorViewController.view]) {
         return;
     }
-
     [self.window addSubview:self.errorViewController.view];
     self.errorViewController.errorMessage.text = errorMessage;
 }
@@ -150,12 +154,6 @@
 - (void)dismissErrorScreen
 {
     [self.errorViewController.view removeFromSuperview];
-}
-
--(void)showAboutScreen
-{
-    AboutViewController *about = [[AboutViewController alloc] initWithNibName:@"AboutView" bundle:nil];
-    [self.navController pushViewController:about animated:YES];
 }
 
 - (void)reloadCoreData


### PR DESCRIPTION
Putting the home page as root viewcontroller for the loginviewcontroller
can lead to user getting to it without login. like going to login with google
and back he will see a back button to it.

This commit creates a standalone Navigation controller for the Login viewcontroller
present it instead of pushing it, and also retouch the affected part.
