### PR TITLE
remove indicator if message row is zero

### DIFF
--- a/Zulip/Controllers/ViewControllers/NarrowViewController.m
+++ b/Zulip/Controllers/ViewControllers/NarrowViewController.m
@@ -82,8 +82,10 @@ typedef enum  {
 
       [self loadMessages:messages];
 
-      if ([self.messages count] == 0)
+      if ([self.messages count] == 0) {
+          self.tableView.tableFooterView = nil;
           return;
+      }
 
       if (isFinished) {
           self.tableView.tableFooterView = nil;

--- a/Zulip/StreamComposeView.m
+++ b/Zulip/StreamComposeView.m
@@ -76,6 +76,7 @@ static const CGFloat StreamComposeViewInputHeight = 30.f;
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapComposeView)];
     [self.tapHandlerShim addGestureRecognizer:tap];
     [self addSubview:self.tapHandlerShim];
+    
 
     [[NSNotificationCenter defaultCenter] addObserverForName:kLogoutNotification
                                                       object:nil
@@ -373,6 +374,9 @@ static const CGFloat StreamComposeViewInputHeight = 30.f;
     self.messageInput.layer.borderWidth = 1.f;
     self.messageInput.delegate = self;
     self.messageInput.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    UITextInputAssistantItem *inputAssistantItem = [self.messageInput inputAssistantItem];
+    inputAssistantItem.leadingBarButtonGroups = @[];
+    inputAssistantItem.trailingBarButtonGroups = @[];
 
     // iOS 6 has a weird bug where vertical alignment is off in the text
     // view because default font sizes different. This is a hacky workaround.


### PR DESCRIPTION
![chat room](https://cloud.githubusercontent.com/assets/5852679/13872727/6b84d192-ed27-11e5-9964-448ea003e197.png)
if the message row is zero, I think we can remove that indicator to prompt user that finish loading.
